### PR TITLE
Avoid harcoding path to KAOSFormalTools 

### DIFF
--- a/KAOSFormalTools.tmbundle/Commands/Export to OmniGraffle.tmCommand
+++ b/KAOSFormalTools.tmbundle/Commands/Export to OmniGraffle.tmCommand
@@ -6,7 +6,7 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>#!/bin/sh
-mono /Users/blambeau/work/devel/KAOSFormalTools/KAOSFormalTools.OmnigraffleExport/bin/Debug/KAOSFormalTools.OmnigraffleExport.exe -o "/tmp/output.graffle" "$TM_FILEPATH"
+mono $KAOS_FORMAL_TOOLS/KAOSFormalTools.OmnigraffleExport/bin/Debug/KAOSFormalTools.OmnigraffleExport.exe -o "/tmp/output.graffle" "$TM_FILEPATH"
 open "/tmp/output.graffle"
 </string>
 	<key>input</key>


### PR DESCRIPTION
The bundle now depends on a KAOS_FORMAL_TOOLS environment variable.
Such variables can be set in TextMate itself under
TextMate > Preferences > Advanced > Shell Variables
